### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "680e5a60ed9dce028b26784e",
+  "nxCloudId": "680e5c053ade4d3322d6a33a",
   "plugins": [
     { "plugin": "@nx/angular/plugin", "options": { "targetNamePrefix": "" } },
     { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/680e5a4d3ade4d3322d6a336/workspaces/680e5c053ade4d3322d6a33a

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.